### PR TITLE
feat(发送组件): 添加停止消息功能

### DIFF
--- a/src/webview/components/sender/index.tsx
+++ b/src/webview/components/sender/index.tsx
@@ -6,7 +6,7 @@ import {
   Select,
   Textarea,
 } from '@heroui/react';
-import { SendHorizontal } from 'lucide-react';
+import { CircleStop, SendHorizontal } from 'lucide-react';
 import { useMemoizedFn } from 'ahooks';
 import cx from 'classnames';
 import CommandTip from './CommandTip';
@@ -28,6 +28,7 @@ interface SenderComProps {
   handleSubmit: (event: any, options: any) => void;
   setMessages: (messages: any[]) => void;
   append: (message: Message) => void;
+  stop: () => void;
 }
 
 export default function SenderCom(props: SenderComProps) {
@@ -70,6 +71,11 @@ export default function SenderCom(props: SenderComProps) {
     },
   );
 
+  const stopMessage = useMemoizedFn(() => {
+    if (submitForbidden) {
+      stop();
+    }
+  });
   const doSubmit = useMemoizedFn(() => {
     if (token && userInfo && !submitForbidden) {
       const newMessage = createNewUserMessage(content, fileInfo);
@@ -127,13 +133,17 @@ export default function SenderCom(props: SenderComProps) {
           <ModelSelectCom></ModelSelectCom>
           <div className="flex gap-2">
             <span></span>
-            <SendHorizontal
-              className={cx(
-                'size-4',
-                submitForbidden ? 'cursor-not-allowed' : 'cursor-pointer',
-              )}
-              onClick={doSubmit}
-            />
+            {submitForbidden ? (
+              <CircleStop
+                className="size-4 cursor-pointer"
+                onClick={stopMessage}
+              ></CircleStop>
+            ) : (
+              <SendHorizontal
+                className={'size-4 cursor-pointer'}
+                onClick={doSubmit}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/src/webview/components/sender/index.tsx
+++ b/src/webview/components/sender/index.tsx
@@ -40,6 +40,7 @@ export default function SenderCom(props: SenderComProps) {
     handleSubmit,
     setMessages,
     append,
+    stop,
   } = props;
   const [isOpen, setIsOpen] = useState(false);
   const { token, userInfo } = useUserStore();

--- a/src/webview/pages/home/index.tsx
+++ b/src/webview/pages/home/index.tsx
@@ -87,6 +87,7 @@ export default function HomePage() {
         status={status}
         fileInfo={fileInfo}
         append={append}
+        stop={stop}
         handleInputChange={handleInputChange}
         handleSubmit={handleSubmit}
         setMessages={setMessages}


### PR DESCRIPTION
在发送组件中新增停止消息功能，当提交被禁止时，用户可以通过点击停止按钮来中断操作。此功能提高了用户体验，允许用户在必要时取消操作。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the messaging interface to display an alternative action when message submission is disabled. Now, when messages cannot be sent, a stop option is presented to clearly signal that submission is not allowed.
	- Updated the main chat view to integrate this new behavior seamlessly.
	- Introduced a new prop to the messaging component to support the updated functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->