### PR TITLE
fix: 缩短新版本提示的显示时间

### DIFF
--- a/src/webview/hooks/useCheckNewRelease.ts
+++ b/src/webview/hooks/useCheckNewRelease.ts
@@ -39,7 +39,7 @@ export const useCheckNewRelease = (checkInterval = 10 * 60 * 1000) => {
           description:
             '当前版本为' + localVersion + '，最新版本为' + remoteVersion,
           color: 'danger',
-          timeout: 10 * 60 * 1000,
+          timeout: 5 * 60 * 1000,
         });
         setHasNewVersion(true);
       } else {


### PR DESCRIPTION
将新版本提示的显示时间从10分钟缩短至5分钟，以提高用户体验并减少不必要的干扰

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Update notifications now automatically dismiss after 5 minutes, instead of 10 minutes, for a less intrusive user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->